### PR TITLE
Ignore read-only mode for extend-rectangle-to-end

### DIFF
--- a/rectangle-utils.el
+++ b/rectangle-utils.el
@@ -54,6 +54,7 @@
   (let ((longest-len (save-excursion
                        (goto-longest-region-line beg end)
                        (length (buffer-substring (point-at-bol) (point-at-eol)))))
+        (inhibit-read-only t) ; ignore read-only status of the buffer
         column-beg column-end)
     (goto-char beg) (setq column-beg (current-column))
     (save-excursion (goto-char end) (setq column-end (current-column)))
@@ -73,8 +74,8 @@
           (goto-char beg)
           (push-mark end 'nomsg 'activate)
           (setq deactivate-mark  nil))
-        (deactivate-mark 'force)
-        (error "Error: not in a rectangular region."))))
+      (deactivate-mark 'force)
+      (error "Error: not in a rectangular region."))))
 
 
 (defvar rectangle-menu


### PR DESCRIPTION
- At times, you need to copy a rectangle selection from a read-only file
  or a read-only buffer like _eww_. That read-only state needs to be
  ignored for `extend-rectangle-to-end` to work.
